### PR TITLE
PFD: show DME distance

### DIFF
--- a/Models/Cockpit/Instruments/PFD/PFD.nas
+++ b/Models/Cockpit/Instruments/PFD/PFD.nas
@@ -121,7 +121,7 @@ var canvas_PFD_main = {
 		return m;
 	},
 	getKeys: func() {
-		return ["ap-alt","ap-alt-capture","IASbug1","IASbug1symbol","IASbug1digit","IASbug2","IASbug2symbol","IASbug2digit","compassrose","IAS.100","IAS.10","ap-hdg","ap-hdg-bug","FMSNAVpointer","FMSNAVdeviation","NavFreq","FMSNAVRadial","FMSNAVdeflectionscale","FMSNAVtext","dh","radaralt","QNH","alt.1000","alt.100","alt.1","alt.1.top","alt.1.btm","VS","horizon","ladder","rollpointer","rollpointer2","asitape","asitapevmo","asi.trend.up","asi.trend.down","alt.tape","VS.needle","AP","ap.lat.engaged","ap.lat.armed","ap.vert.eng","ap.vert.value","ap.vert.arm","altTextLowSmall1","altTextHighSmall2","altTextLow1","altTextHigh1","altTextHigh2","alt.low.digits","alt.bug","alt.bug.top","alt.bug.btm","asi.rollingdigits","NavFreq","ADF1symbol","ADF1text","ADF1ind","ADF2text","ADF2symbol","ADF2ind"];
+		return ["ap-alt","ap-alt-capture","IASbug1","IASbug1symbol","IASbug1digit","IASbug2","IASbug2symbol","IASbug2digit","compassrose","IAS.100","IAS.10","ap-hdg","ap-hdg-bug","FMSNAVpointer","FMSNAVdeviation","NavFreq","FMSNAVRadial","FMSNAVdeflectionscale","FMSNAVtext","dh","radaralt","QNH","alt.1000","alt.100","alt.1","alt.1.top","alt.1.btm","VS","horizon","ladder","rollpointer","rollpointer2","asitape","asitapevmo","asi.trend.up","asi.trend.down","alt.tape","VS.needle","AP","ap.lat.engaged","ap.lat.armed","ap.vert.eng","ap.vert.value","ap.vert.arm","altTextLowSmall1","altTextHighSmall2","altTextLow1","altTextHigh1","altTextHigh2","alt.low.digits","alt.bug","alt.bug.top","alt.bug.btm","asi.rollingdigits","NavFreq","ADF1symbol","ADF1text","ADF1ind","ADF2text","ADF2symbol","ADF2ind","DMEdist"];
 	},
 	fast_update: func() {
 	
@@ -396,6 +396,8 @@ var canvas_PFD_main = {
 			me["ADF2symbol"].hide();
 			me["ADF2ind"].hide();
 		}
+
+		me["DMEdist"].setText(sprintf("%s",getprop("instrumentation/dme[0]/KDI572-574/nm")));
 		
 		var radaralti=getprop("/position/gear-agl-ft") or 0;
 		if(radaralti<2500 and radaralti>0){

--- a/Models/Cockpit/Instruments/PFD/PFD.svg
+++ b/Models/Cockpit/Instruments/PFD/PFD.svg
@@ -828,15 +828,15 @@
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:36.38011169px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="210.50154"
+       x="175.50154"
        y="881.2027"
-       id="text5090"
+       id="DMEdist"
        sodipodi:linespacing="125%"
        transform="scale(0.92478652,1.0813306)"><tspan
          sodipodi:role="line"
          id="tspan5092"
-         x="210.50154"
-         y="881.2027">00</tspan></text>
+         x="175.50154"
+         y="881.2027">000</tspan></text>
     <path
        id="ap-hdg-bug"
        style="fill:none;fill-rule:evenodd;stroke:#0098ff;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"


### PR DESCRIPTION
Thanks for including the ADF bearing fix. Sorry I left extra brackets behind!

I navigate mostly using VOR/DME and I noticed the DME distance was not showing on the PFD.  I checked PFD.nas2 and saw that had DME distance so I copied the property update from there.  I had to move the digits to the left in the SVG to fit them before the units display ('NM') in all cases (close to DME, e.g. 0.2; further from DME, e.g. 10.4, and > 100NM from DME e.g. 102).

This is the first time I've tried to make changes like this to a display in FlightGear so not sure if I've done it correctly.  There may be better ways to format/align the digits with sprintf/SVG.  Please feel free to close/reject this PR if you are already working on instrument display refactoring.